### PR TITLE
Update Head.java

### DIFF
--- a/sdm/src/java/association/Head.java
+++ b/sdm/src/java/association/Head.java
@@ -2,7 +2,7 @@ package src.java.association;
 
 public class Head
 {
-    int count;
+    int count; // Must be private and final, see also my comments below.
     Head(int count)
     {
         this.count = count;


### PR DESCRIPTION
Does it make sense to have a count of "heads" in one instance of the Head class?
If an individual could have more than one head, then it should be the Person class (or similar) that knows it, not the Head class.
Also, all "body parts" could derive from a common superclass BodyPart that could factor out common code.